### PR TITLE
Fix bad map cache dir generation

### DIFF
--- a/mushr_rhc_ros/src/librhc/utils/cache.py
+++ b/mushr_rhc_ros/src/librhc/utils/cache.py
@@ -25,4 +25,4 @@ def get_cache_dir(params, path):
 
 
 def get_cache_map_dir(params, map):
-    return get_cache_dir(params, map.name)
+    return get_cache_dir(params, 'mapres_%dh_%dw'%(map.height,map.width))


### PR DESCRIPTION
Currently it uses map.name to generate the map cache dir for saving the permissibility region. Unfortunately, map.name returns "map", rather than the image file of the map. It doesn't look like there's a simple way to get the image file path from the map topic, so I suggest using the map resolution as a unique identifier (maybe chuck in the scale as well?) it's certainly not foolproof, but it's a start.